### PR TITLE
New Quirk: Appendicitis Survivor

### DIFF
--- a/modular_skyrat/master_files/code/datums/traits/good.dm
+++ b/modular_skyrat/master_files/code/datums/traits/good.dm
@@ -128,3 +128,17 @@
 	lose_text = span_danger("Somehow, you've completely cleaned yourself of glitter..")
 	medical_record_text = "Patient seems to be looking fabulous."
 	icon = FA_ICON_HAND_SPARKLES
+
+/datum/quirk/no_appendix
+	name = "Appendicitis Survivor"
+	desc = "You had a run in with appendicitis in the past and no longer have an appendix."
+	icon = FA_ICON_NOTES_MEDICAL
+	value = 2
+	gain_text = span_notice("You no longer have an appendix.")
+	lose_text = span_danger("You miss your appendix?")
+	medical_record_text = "Patient had appendicitis in the past and has had their appendix surgically removed."
+
+/datum/quirk/no_appendix/post_add()
+	var/mob/living/carbon/carbon_quirk_holder = quirk_holder
+	var/obj/item/organ/internal/appendix/dumb_appendix = carbon_quirk_holder.get_organ_slot(ORGAN_SLOT_APPENDIX)
+	dumb_appendix?.Remove(quirk_holder, TRUE)


### PR DESCRIPTION
## About The Pull Request
Title.

## How This Contributes To The Nova Sector Roleplay Experience
Spontaneous appendicitis is.. an event!

This adds the Appendicitis Survivor quirk from my server, [TaleStation](https://github.com/TaleStation/TaleStation).

Its a positive (-2) quirk, while low impact, some people may appreciate. Its also another low cost quirk, so people could pick it up if so desired. 

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/GalacticStation/GalaxiaStation/assets/70232195/1f807368-f811-4d1d-b2c5-34f8508e6fcb)

  
</details>

## Changelog

:cl: Jolly
add: New quirk for those who hate their appendix: Appendicitis Survivor! A positive (-2) quirk.
/:cl:
