### PR TITLE
Primitive Demihumans now speak uncommon

### DIFF
--- a/modular_skyrat/modules/primitive_catgirls/code/species.dm
+++ b/modular_skyrat/modules/primitive_catgirls/code/species.dm
@@ -5,10 +5,12 @@
 	understood_languages = list(
 		/datum/language/primitive_catgirl = list(LANGUAGE_ATOM),
 		/datum/language/siiktajr = list(LANGUAGE_ATOM),
+		/datum/language/uncommon = list(LANGUAGE_ATOM),
 	)
 	spoken_languages = list(
 		/datum/language/primitive_catgirl = list(LANGUAGE_ATOM),
 		/datum/language/siiktajr = list(LANGUAGE_ATOM),
+		/datum/language/uncommon = list(LANGUAGE_ATOM),
 	)
 	selected_language = /datum/language/primitive_catgirl
 
@@ -21,7 +23,7 @@
 	mutanttongue = /obj/item/organ/internal/tongue/cat/primitive
 
 	species_language_holder = /datum/language_holder/primitive_felinid
-	language_prefs_whitelist = list(/datum/language/primitive_catgirl)
+	language_prefs_whitelist = list(/datum/language/primitive_catgirl, /datum/language/common)
 
 	bodytemp_normal = 270 // If a normal human gets hugged by one its gonna feel cold
 	bodytemp_heat_damage_limit = 283 // To them normal station atmos would be sweltering


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

can i tell you something if you don't think its weird i like having my balls kicked did you see my message i like having my balls kicked did you get my last message i like getting kicked in the balls

## How This Contributes To The Nova Sector Roleplay Experience

As is Hearthkin roleplay can be very limited due to the languages which the ice cats possess. Communication (vocally) to the station is all but impossible due to the fact that nobody takes Siik'Tjar, leaving hearthkin to pantomime and charade whenever they wish to ask a question to the outlanders.

This doesn't make it so that Hearthkin can communicate with everybody, it just makes it a lot more likely that they find SOMEBODY who can speak their language. I can not stress enough how little people take Siik'Tjar

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Hearthkin now speak uncommon
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
