### PR TITLE
Icewalker botany improvements: guaranteed polypore, embershroom spawns, plus watermelon and grass seeds

### DIFF
--- a/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_icewalker_lower.dmm
+++ b/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_icewalker_lower.dmm
@@ -243,7 +243,7 @@
 /turf/open/misc/dirt/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "fY" = (
-/obj/structure/flora/ash/cap_shroom,
+/obj/structure/flora/ash,
 /turf/open/misc/dirt/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "gt" = (
@@ -342,6 +342,7 @@
 /obj/item/seeds/plum,
 /obj/item/seeds/berry,
 /obj/item/seeds/grape,
+/obj/item/seeds/watermelon,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "iJ" = (
@@ -389,6 +390,10 @@
 	dir = 8
 	},
 /obj/structure/stairs/wood,
+/turf/open/misc/dirt/icemoon,
+/area/ruin/unpowered/primitive_catgirl_den)
+"jO" = (
+/obj/structure/flora/ash/stem_shroom,
 /turf/open/misc/dirt/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "jV" = (
@@ -845,6 +850,10 @@
 	},
 /turf/open/misc/dirt/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
+"sf" = (
+/obj/structure/flora/ash/cap_shroom,
+/turf/open/misc/dirt/icemoon,
+/area/ruin/unpowered/primitive_catgirl_den)
 "su" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -990,6 +999,7 @@
 /obj/item/seeds/tea/catnip,
 /obj/item/seeds/bamboo,
 /obj/item/seeds/ambrosia,
+/obj/item/seeds/grass,
 /turf/open/misc/dirt/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "wF" = (
@@ -2955,7 +2965,7 @@ oJ
 pa
 GN
 GN
-fY
+jO
 jV
 Oy
 MP
@@ -3215,7 +3225,7 @@ GN
 GN
 GN
 mu
-fY
+sf
 GN
 pa
 hA


### PR DESCRIPTION
## About The Pull Request

Adds guaranteed spawns for polypore mushrooms (tall mushrooms) and embershrooms (numerous mushrooms) to the Icewalker hearth, as well as watermelon and grass seeds.

## How This Contributes To The Nova Station Roleplay Experience

These four plants are the last missing pieces needed to make Icewalker botany an interesting experience without slogging through seed mesh RNG. Seriously, icemoon seed meshing blows ass. To better portray what this provides access to:

- Polypore mushrooms provide easy access to a source of stabilizing agent, allowing them to create advanced chems with stable plasma components.
     - Cryoxadone is the most obvious chemical here, and has a funny interaction with Icewalkers subzero internal temperature.
     - A new age of icewalker pyrotechnics, with access to pyrosium, phlogiston, teslium, liquid dark matter and more.
     - Eigenstasium. Teleporting icecats, who have easy access to bluespace dust via icemoon mobs.
- Embershrooms provide access to tinea luxor, which allows icecats to create slime jelly chems via an oil/tinea luxor/radium interaction inside glowshroom stems. 
     - This includes regenerative jelly and pyroxadone, in combination with the above. 
     - *Note: this also theoretically allows for hilariously basic icecat slime ranching via the slime extractification reaction and a HUGE amount of effort, since most slimes will immediately die to the icemoon cold.*
- Watermelon provides access to barrelmelons and holymelons.
     - Barrelmelons ferment into antihol, which is a very low potency toxin healing chem and is useful for defuckulating overeager drinkers who are five minutes away from liver failure.
     - Holymelons provide access to holy water, the last component in strange reagent production for totally native icecat and simple/basicmob resurrection. Shamans rejoice! Raise your wolves from the dead in a great ceremony!
- Grass can be shoveled into sand, making icecat farmers no longer want to commit die when trying to produce things that require it.

More options is always fun. In addition, nothing described above is easy to achieve and requires competence with tribal chemistry. Gives healers, farmers and alchemists much more to do in a round, and also improves parity with Ashwalker chemistry.

As an extra note, you could already make all of these things listed above if you were willing to commit potentially two and a half hours of your three hour shift to seed meshing all the required things for it.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

![dreamseeker_2JaYbiziYH](https://github.com/Skyrat-SS13/Skyrat-tg/assets/966289/8f183a28-93e9-4862-b3ee-6d2d1011c6ad)

![dreamseeker_gsXESw3Nm5](https://github.com/Skyrat-SS13/Skyrat-tg/assets/966289/8eda5711-59a3-4922-a1bc-587bfcc89881)

![dreamseeker_oXT5ebDU8G](https://github.com/Skyrat-SS13/Skyrat-tg/assets/966289/4f1656a0-b284-4199-9a1f-25d508c0e05c)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: yooriss
balance: The sacred waters of the Icewalker's Hearth now ensure that polypore mushrooms and embershrooms are always available for intrepid botanists to use in their concoctions.
add: Watermelon and grass seeds are now available in the Hearth's seed stores.
/:cl: