### PR TITLE
The Thrill of the Hunt: Hemophage blood digestion changes

### DIFF
--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/corrupted_tongue.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/corrupted_tongue.dm
@@ -102,11 +102,20 @@
 	// We start by checking that the victim is a human and they have a client, so we can give them the
 	// beneficial status effect for drinking higher-quality blood.
 	var/is_target_human_with_client = istype(victim, /mob/living/carbon/human) && victim.client
+	var/horrible_feeding = FALSE
 
 	if(ismonkey(victim))
 		is_target_human_with_client = FALSE // Sorry, not going to get the status effect from monkeys, even if they have a client in them.
-
+		hemophage.add_mood_event("gross_food", /datum/mood_event/disgust/hemophage_feed_monkey) // drinking from a monkey is inherently gross, like, REALLY gross
+		hemophage.adjust_disgust(DISGUST_LEVEL_GROSS + 15, DISGUST_LEVEL_MAXEDOUT)
 		blood_volume_difference = BLOOD_VOLUME_NORMAL - hemophage.blood_volume
+		horrible_feeding = TRUE
+
+	if(istype(victim, /mob/living/carbon/human/species/monkey))
+		is_target_human_with_client = FALSE // yep you're still not getting the status effect from humonkeys either. your tumour knows.
+		hemophage.add_mood_event("gross_food", /datum/mood_event/disgust/hemophage_feed_humonkey)
+		hemophage.adjust_disgust(DISGUST_LEVEL_GROSS / 4, DISGUST_LEVEL_GROSS) // it's still gross but nowhere near as bad, though.
+		horrible_feeding = TRUE
 
 	StartCooldown()
 
@@ -129,18 +138,33 @@
 
 	log_combat(hemophage, victim, "drained [drained_blood]u of blood from", addition = " (NEW BLOOD VOLUME: [victim.blood_volume] cL)")
 	victim.show_message(span_danger("[hemophage] drains some of your blood!"))
-	to_chat(hemophage, span_notice("You drink some blood from [victim]![is_target_human_with_client ? " That tasted particularly good!" : ""]"))
+
+	if(horrible_feeding)
+		if(istype(victim, /mob/living/carbon/human/species/monkey))
+			to_chat(hemophage, span_notice("You take tentative draws of blood from [victim], each mouthful awash with the taste of ozone and a strange artificial twinge."))
+		else
+			to_chat(hemophage, span_warning("You choke back tepid mouthfuls of foul blood from [victim]. The taste is absolutely vile."))
+	else
+		to_chat(hemophage, span_notice("You pull greedy gulps of precious lifeblood from [victim]'s veins![is_target_human_with_client ? " That tasted particularly good!" : ""]"))
 
 	playsound(hemophage, 'sound/items/drink.ogg', 30, TRUE, -2)
 
 	if(victim.blood_volume <= BLOOD_VOLUME_OKAY)
 		to_chat(hemophage, span_warning("That definitely left them looking pale..."))
+		to_chat(victim, span_warning("A groaning lethargy creeps into your muscles as you begin to feel slightly clammy...")) //let the victim know too
 
 	if(is_target_human_with_client)
 		hemophage.apply_status_effect(/datum/status_effect/blood_thirst_satiated)
+		hemophage.add_mood_event("drank_human_blood", /datum/mood_event/hemophage_feed_human) // absolutely scrumptious
+		hemophage.clear_mood_event("gross_food") // it's a real palate cleanser, you know
+		hemophage.disgust *= 0.85 //also clears a little bit of disgust too
 
 	if(!victim.blood_volume || victim.blood_volume < BLOOD_VOLUME_SURVIVE)
-		to_chat(hemophage, span_warning("You finish off [victim]'s blood supply."))
+		to_chat(hemophage, span_warning("You drain the last drop of blood from [victim]'s barren veins."))
+		if (is_target_human_with_client)
+			to_chat(hemophage, span_boldnotice("A rush of unbidden exhilaration surges through you as the predatory urges of your terrible coexistence are momentarily sated."))
+			hemophage.add_mood_event("hemophage_killed", /datum/mood_event/hemophage_exsanguinate) // this is the tumour-equivalent of a nice little headpat. you murderer, you!
+			hemophage.disgust = 0 // all is forgiven.
 
 
 #undef HEMOPHAGE_DRAIN_AMOUNT

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_moods.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_moods.dm
@@ -1,0 +1,24 @@
+/datum/mood_event/hemophage_feed_human
+	description = "I slaked my hunger on fresh, vital blood. That felt good!"
+	mood_change = 2
+	timeout = 5 MINUTES
+
+/datum/mood_event/disgust/hemophage_feed_monkey
+	description = "I had to feed off a gibbering monkey... what have I become?"
+	mood_change = -4
+	timeout = 5 MINUTES
+
+/datum/mood_event/disgust/hemophage_feed_humonkey
+	description = "Somehow I know deep down that humonkey blood is no substitute for the real thing..."
+	mood_change = -1
+	timeout = 5 MINUTES
+
+/datum/mood_event/disgust/hemophage_feed_synthesized_blood
+	description = "My last blood meal was artificial and tasted... wrong."
+	mood_change = -2
+	timeout = 5 MINUTES
+
+/datum/mood_event/hemophage_exsanguinate
+	description = "I drained someone of all their blood... why do I feel so giddy?"
+	mood_change = 4
+	timeout = 60 MINUTES //nova rounds last ages and you're not going to be doing this often.

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_organs.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_organs.dm
@@ -85,6 +85,10 @@
 	var/datum/reagent/blood/blood = reagents.has_reagent(/datum/reagent/blood)
 	if(blood)
 		blood.metabolization_rate = BLOOD_METABOLIZATION_RATE
+		var/blood_DNA = blood.data["blood_DNA"]
+		if (!blood_DNA) //does the blood we're digesting have any DNA? if it doesn't, it's artificial, and that's gross.
+			src.owner.adjust_disgust(DISGUST_LEVEL_GROSS / 16, DISGUST_LEVEL_VERYGROSS)
+			src.owner.add_mood_event("gross_food", /datum/mood_event/disgust/hemophage_feed_synthesized_blood)
 
 	return ..()
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7080,6 +7080,7 @@
 #include "modular_nova\modules\customization\modules\mob\living\carbon\human\species\hemophage\corrupted_stomach.dm"
 #include "modular_nova\modules\customization\modules\mob\living\carbon\human\species\hemophage\corrupted_tongue.dm"
 #include "modular_nova\modules\customization\modules\mob\living\carbon\human\species\hemophage\hemophage_actions.dm"
+#include "modular_nova\modules\customization\modules\mob\living\carbon\human\species\hemophage\hemophage_moods.dm"
 #include "modular_nova\modules\customization\modules\mob\living\carbon\human\species\hemophage\hemophage_organs.dm"
 #include "modular_nova\modules\customization\modules\mob\living\carbon\human\species\hemophage\hemophage_species.dm"
 #include "modular_nova\modules\customization\modules\mob\living\carbon\human\species\hemophage\hemophage_status_effects.dm"


### PR DESCRIPTION
## About The Pull Request

Current lore establishes hemophages as creatures bound by a horrible blood thirst. A few months of watching Other Station hemophage players drag monkeys around and harangue medbay has asserted quite firmly to me that very few people are actually playing this out in practice - and why would they, when there's no real mechanical impetus to do so?

This PR does the following to enhance hemophage flavour:

- Drinking from a standard monkey mob inflicts a -4 moodlet debuff for 5 minutes. This is on par with being hungover or untreated spacer grav sickness. It is also *really* gross and may make the hemophage nauseous to the point of stammering and vomiting if they keep doing it.
- Digesting synthetic blood from *any* source will apply a -2 moodlet debuff for 5 minutes. This is on par with smoking a brand of cigarettes you don't like, or eating a food type you don't like. This includes synthetic blood used in hemophage foods, as well.
- Drinking from a humonkey (a monkey changed into a human via DNA scanner) inflicts a -1 moodlet debuff for 5 minutes. This is on par with being operated on a numbing surgery table while conscious. It is also gross, but *way* less gross.
- Drinking from another humanoid player will apply a +2 moodlet buff for 5 minutes and reduces your total disgust by 15% of its maximum value. This may prove more incidentally useful than you realize in combination with certain drugs.
- Should you kill someone by draining out *all* of their blood, you gain a whopping **+4** moodlet buff for **SIXTY MINUTES**. Your predatory tumour enjoys it when you murder people. Who could've guessed? This will also zero out your disgust from *any* source.
- In addition, most hemophage blood drain lines have had their flavour improved and their "worth" made more obvious to the player.
- Also, victims having their blood drained below safe levels now immediately feel something is not quite right. Uh oh.

You can circumvent these moodlet issues with an IV administration of blood (if you're boring), but at least it gives doctors something to do.

## How This Contributes To The Nova Sector Roleplay Experience

This should encourage hemophages to do more hemophagey things. You can feed from monkeys in a pinch, and humonkeys remain a long term option with a little help from your local geneticist if you really want to remain a "herbivore" hemophage. Struggle with the temptation to drain an annoying coworker to death in maintenance for an hour long moodlet like the vampire counts intended.

Especially intrepid hemophages may even now actually decide to make use of the hemophage food offerings available to help manage their mood. With real blood *ethically* sourced from the crew, of course.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
 
![dreamseeker_zzWNOvuLxQ](https://github.com/GalacticStation/GalaxiaStation/assets/966289/99f3cae8-fef9-4a4c-bf90-ce0f1f8d9a37)

</details>

## Changelog

:cl: yooriss
balance: Hemophages are now properly disgusted and suffer a 5 minute mood debuff by consuming blood from monkey-adjacent sources, and also find synthetic blood slightly gross while digesting it.
balance: When hemophages drink blood from another player character with an active mind, they receive a small mood boost for 5 minutes.
balance: Hemophages now receive a strong mood boost that lasts 60 minutes from killing someone by draining all of their blood.
/:cl:
